### PR TITLE
fixed missing declare

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-namespace Cypress {
+declare namespace Cypress {
   interface Chainable<Subject = any> {
     /**
      * Starts a time span using the User Timings API. A `cy.time`


### PR DESCRIPTION
error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier